### PR TITLE
20 featcommunity update delete posts

### DIFF
--- a/src/app/community/(category)/ohjiwan/page.tsx
+++ b/src/app/community/(category)/ohjiwan/page.tsx
@@ -10,7 +10,10 @@ const CommunityOhjiwan = () => {
   const { isLoading, data: ohjiwanPosts, error } = useQuery<PostType[]>(
     ["ohjiwanPosts"],
     () => getOhjiwanPosts(),
-    { cacheTime: 5000 },
+    {
+      staleTime: 60000,
+      cacheTime: 120000
+    },
   );  
 
 if (isLoading) return "오지완 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/ohjiwan/page.tsx
+++ b/src/app/community/(category)/ohjiwan/page.tsx
@@ -10,6 +10,7 @@ const CommunityOhjiwan = () => {
   const { isLoading, data: ohjiwanPosts, error } = useQuery<PostType[]>(
     ["ohjiwanPosts"],
     () => getOhjiwanPosts(),
+    { cacheTime: 5000 },
   );  
 
 if (isLoading) return "오지완 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/product/page.tsx
+++ b/src/app/community/(category)/product/page.tsx
@@ -10,7 +10,10 @@ const CommunityProduct = () => {
   const { isLoading, data: productPosts, error } = useQuery<PostType[]>(
     ["productPosts"],
     () => getProductPosts(),
-    { cacheTime: 5000 }
+    {
+      staleTime: 60000,
+      cacheTime: 120000
+    },
   );  
 
 if (isLoading) return "제품 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/product/page.tsx
+++ b/src/app/community/(category)/product/page.tsx
@@ -10,6 +10,7 @@ const CommunityProduct = () => {
   const { isLoading, data: productPosts, error } = useQuery<PostType[]>(
     ["productPosts"],
     () => getProductPosts(),
+    { cacheTime: 5000 }
   );  
 
 if (isLoading) return "제품 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/recipe/page.tsx
+++ b/src/app/community/(category)/recipe/page.tsx
@@ -10,7 +10,10 @@ const CommunityRecipe = () => {
   const { isLoading, data: recipePosts, error } = useQuery<PostType[]>(
     ["recipePosts"],
     () => getRecipePosts(),
-    { cacheTime: 5000 }
+    {
+      staleTime: 60000,
+      cacheTime: 120000
+    },
   );  
 
 if (isLoading) return "레시피 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/recipe/page.tsx
+++ b/src/app/community/(category)/recipe/page.tsx
@@ -10,6 +10,7 @@ const CommunityRecipe = () => {
   const { isLoading, data: recipePosts, error } = useQuery<PostType[]>(
     ["recipePosts"],
     () => getRecipePosts(),
+    { cacheTime: 5000 }
   );  
 
 if (isLoading) return "레시피 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/restaurant/page.tsx
+++ b/src/app/community/(category)/restaurant/page.tsx
@@ -10,6 +10,7 @@ const CommunityRestaurant = () => {
   const { isLoading, data: restaurantPosts, error } = useQuery<PostType[]>(
     ["restaurantPosts"],
     () => getRestaurantPosts(),
+    { cacheTime: 5000 }
   );  
 
 if (isLoading) return "식당 카테고리 게시글 로딩중";

--- a/src/app/community/(category)/restaurant/page.tsx
+++ b/src/app/community/(category)/restaurant/page.tsx
@@ -10,7 +10,10 @@ const CommunityRestaurant = () => {
   const { isLoading, data: restaurantPosts, error } = useQuery<PostType[]>(
     ["restaurantPosts"],
     () => getRestaurantPosts(),
-    { cacheTime: 5000 }
+    {
+      staleTime: 60000,
+      cacheTime: 120000
+    },
   );  
 
 if (isLoading) return "식당 카테고리 게시글 로딩중";

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,51 +1,9 @@
-"use client";
-import Link from "next/link";
-
-import { useQuery } from "@tanstack/react-query";
-import { getPosts } from "@/api/community/post";
-
-import { useRouter } from "next/navigation";
-
-import { Database } from "@/types/supabase";
-type PostType = Database["public"]["Tables"]["community"]["Row"];
+import GetPosts from "@/components/community/GetPosts";
 
 const Community = () => {
-  const router = useRouter();
-  const { isLoading, data: posts, error } = useQuery<PostType[]>(
-    ["communityAllPosts"],
-    () => getPosts(),
-  );
-
-  if (isLoading) return "커뮤니티 게시글 로딩중";
-  if (error) {
-    console.error("데이터를 불러오는 중에 오류가 발생했습니다:", error);
-    return "데이터를 불러오는 중에 오류가 발생했습니다.";
-  }
   return (
-    <>
-      <h1 className="text-xl flex justify-center items-center mx-auto mt-10">전체 카테고리 게시글 목록</h1>
-      {
-        <div className="flex flex-col max-w-7xl my-10 mx-auto items-center justify-center">
-        {Array.isArray(posts) && posts.map((post: PostType) => (
-            <div
-              key={post.post_uid}
-              className="flex justify-between w-3/4 border px-4 py-7 mb-2 rounded-md"
-            >
-              <div className="flex">
-                <span className="w-32">{post.category}</span>
-                <h4 className="cursor-pointer hover:text-green-400">
-                  <Link href={`/community/${post.post_uid}`}>
-                    {post.title}
-                  </Link>
-                </h4>
-              </div>
-              <span>{post.created_date}</span>
-            </div>
-          ))}
-        </div>
-      }
-    </>
-  );
+    <GetPosts />
+  )
 };
 
 export default Community;

--- a/src/components/community/AddPost.tsx
+++ b/src/components/community/AddPost.tsx
@@ -39,10 +39,11 @@ const AddPost: NextComponentType = () => {
     e.preventDefault();
     const writtenTime = new Date();
     const newPost: NewPost = {
-      author_uid: "bd2125b8-d852-485c-baf3-9c7a8949beee",
       category,
       title,
       content,
+      author_uid: "bd2125b8-d852-485c-baf3-9c7a8949beee",
+      author_name: "테스트닉네임",
       created_date: convertTimestamp(writtenTime),
       updated_date: convertTimestamp(writtenTime)
     }

--- a/src/components/community/DetailPost.tsx
+++ b/src/components/community/DetailPost.tsx
@@ -28,6 +28,10 @@ const DetailPost = () => {
     },
   });
 
+  const handleEdit = () => {
+    // 수정 로직
+  }
+
   const handleDelete = () => {
     const ok = window.confirm("게시글을 정말 삭제하시겠습니까?");
     if (!ok) return false;
@@ -49,7 +53,9 @@ const DetailPost = () => {
             {postDetail?.title}
           </h1>
           <div className="flex space-x-3">
-            <button className="w-20 text-sm border-b-4 border-blue-300 px-5 pb-1 shadow-sm hover:-translate-y-1 transition ease-in-out duration-200">
+            <button
+              onClick={handleEdit}
+              className="w-20 text-sm border-b-4 border-blue-300 px-5 pb-1 shadow-sm hover:-translate-y-1 transition ease-in-out duration-200">
               수정
             </button>
             <button

--- a/src/components/community/DetailPost.tsx
+++ b/src/components/community/DetailPost.tsx
@@ -9,8 +9,9 @@ type PostType = Database["public"]["Tables"]["community"]["Row"];
 const DetailPost = () => {
   const { postUid } = useParams();
   const { data: postDetail } = useQuery<PostType>(
-    ["postDetail"],
+    ["postDetail", postUid],
     () => getPostDetail(postUid),
+    { cacheTime: 0 },
   );
   const router = useRouter();
 

--- a/src/components/community/DetailPost.tsx
+++ b/src/components/community/DetailPost.tsx
@@ -14,7 +14,6 @@ const DetailPost = () => {
   );
   const router = useRouter();
 
-
   const queryClient = useQueryClient();
   const deleteMutation = useMutation(deletePost, {
     onSuccess: () => {

--- a/src/components/community/DetailPost.tsx
+++ b/src/components/community/DetailPost.tsx
@@ -29,10 +29,10 @@ const DetailPost = () => {
   });
 
   const handleDelete = () => {
-    const ok = window.confirm("게시글을 정말 삭제하시겠습니까?")
+    const ok = window.confirm("게시글을 정말 삭제하시겠습니까?");
     if (!ok) return false;
     if (ok) deleteMutation.mutate(postUid);
-  }
+  };
 
   return (
     <div className="flex flex-col max-w-7xl mt-10 px-10 mx-auto">
@@ -42,22 +42,33 @@ const DetailPost = () => {
       >
         뒤로가기
       </button>
-      <div className="flex space-x-3 mb-10">
-        <button className="w-20 text-sm border-b-4 border-blue-300 px-5 pb-1 shadow-sm hover:-translate-y-1 transition ease-in-out duration-200">
-          수정
-        </button>
-        <button
-          onClick={handleDelete}
-          className="w-20 text-sm border-b-4 border-blue-300 px-5 pb-1 shadow-sm hover:-translate-y-1 transition ease-in-out duration-200">
-          삭제
-        </button>
-      </div>
       <div className="flex flex-col">
+        <h2 className="text-lg mb-3 text-gray-400 font-semibold">{postDetail?.category}</h2>
         <div className="flex items-end justify-between space-x-5 pb-5 border-b">
           <h1 className="text-3xl text-gray-700 font-semibold">
             {postDetail?.title}
           </h1>
-          <span className="text-sm">{postDetail?.updated_date}</span>
+          <div className="flex space-x-3">
+            <button className="w-20 text-sm border-b-4 border-blue-300 px-5 pb-1 shadow-sm hover:-translate-y-1 transition ease-in-out duration-200">
+              수정
+            </button>
+            <button
+              onClick={handleDelete}
+              className="w-20 text-sm border-b-4 border-blue-300 px-5 pb-1 shadow-sm hover:-translate-y-1 transition ease-in-out duration-200">
+              삭제
+            </button>
+          </div>
+        </div>
+        <div className="flex justify-between mt-3">
+          <div className="flex space-x-5 items-center">
+            <span>{postDetail?.author_name}</span>
+            <span className="text-sm">{postDetail?.updated_date}</span>
+          </div>
+          <div className="flex space-x-3">
+            <span>조회수 0</span>
+            <span>댓글 {postDetail?.number_comments ?? 0}</span>
+            <span>좋아요 0</span>
+          </div>
         </div>
         {
           postDetail &&

--- a/src/components/community/GetPosts.tsx
+++ b/src/components/community/GetPosts.tsx
@@ -34,11 +34,14 @@ const GetPosts = () => {
             >
               <div className="flex">
                 <span className="w-32">{post.category}</span>
-                <h4 className="cursor-pointer hover:text-green-400">
-                  <Link href={`/community/${post.post_uid}`}>
-                    {post.title}
-                  </Link>
-                </h4>
+              <div
+                onClick={()=>router.push(`/community/${post.post_uid}`)}
+                className="flex items-center space-x-2 cursor-pointer hover:text-green-400">
+                  <h4>{post.title}</h4>
+                  <span className="text-sm text-gray-500">
+                    ({post.number_comments})
+                  </span>
+                </div>
               </div>
               <span>{post.created_date}</span>
             </div>

--- a/src/components/community/GetPosts.tsx
+++ b/src/components/community/GetPosts.tsx
@@ -14,6 +14,7 @@ const GetPosts = () => {
   const { isLoading, data: posts, error } = useQuery<PostType[]>(
     ["communityAllPosts"],
     () => getPosts(),
+    { cacheTime: 5000 },
   );
 
   if (isLoading) return "커뮤니티 게시글 로딩중";

--- a/src/components/community/GetPosts.tsx
+++ b/src/components/community/GetPosts.tsx
@@ -1,38 +1,51 @@
-// import supabase from "@/libs/supabase";
-// import { Database } from "@/types/supabase";
-// import Link from "next/link";
+"use client";
+import Link from "next/link";
 
-// type PostType = Database["public"]["Tables"]["community"]["Row"];
+import { useQuery } from "@tanstack/react-query";
+import { getPosts } from "@/api/community/post";
 
-// export const revalidate = 60;
+import { useRouter } from "next/navigation";
 
-// const GetPosts = async () => {
-//   const { data: posts } = await supabase
-//     .from("community")
-//     .select("*")
-//     .order("created_date", { ascending: false });
-//   console.log("getPosts data >> ", posts);
-//   if (!posts) { throw new Error("게시글을 불러오는데 실패하였습니다.")}
-//   return (
-//     <div className="flex flex-col my-10 mx-auto items-center justify-center">
-//       {posts?.map((post: PostType) => (
-//         <div
-//           key={post.post_uid}
-//           className="flex justify-between w-3/4 border px-4 py-7 mb-2 rounded-md"
-//         >
-//           <div className="flex">
-//             <span className="w-32">{post.category}</span>
-//             <h4 className="cursor-pointer hover:text-green-400">
-//               <Link href={`/community/${post.post_uid}`}>
-//                 {post.title}
-//               </Link>
-//             </h4>
-//           </div>
-//           <span>{post.created_date}</span>
-//         </div>
-//       ))}
-//     </div>
-//   );
-// };
+import { Database } from "@/types/supabase";
+type PostType = Database["public"]["Tables"]["community"]["Row"];
 
-// export default GetPosts;
+const GetPosts = () => {
+  const router = useRouter();
+  const { isLoading, data: posts, error } = useQuery<PostType[]>(
+    ["communityAllPosts"],
+    () => getPosts(),
+  );
+
+  if (isLoading) return "커뮤니티 게시글 로딩중";
+  if (error) {
+    console.error("데이터를 불러오는 중에 오류가 발생했습니다:", error);
+    return "데이터를 불러오는 중에 오류가 발생했습니다.";
+  }
+  return (
+    <>
+      <h1 className="text-xl flex justify-center items-center mx-auto mt-10">전체 카테고리 게시글 목록</h1>
+      {
+        <div className="flex flex-col max-w-7xl my-10 mx-auto items-center justify-center">
+        {Array.isArray(posts) && posts.map((post: PostType) => (
+            <div
+              key={post.post_uid}
+              className="flex justify-between w-3/4 border px-4 py-7 mb-2 rounded-md"
+            >
+              <div className="flex">
+                <span className="w-32">{post.category}</span>
+                <h4 className="cursor-pointer hover:text-green-400">
+                  <Link href={`/community/${post.post_uid}`}>
+                    {post.title}
+                  </Link>
+                </h4>
+              </div>
+              <span>{post.created_date}</span>
+            </div>
+          ))}
+        </div>
+      }
+    </>
+  );
+};
+
+export default GetPosts;

--- a/src/components/community/GetPosts.tsx
+++ b/src/components/community/GetPosts.tsx
@@ -14,7 +14,10 @@ const GetPosts = () => {
   const { isLoading, data: posts, error } = useQuery<PostType[]>(
     ["communityAllPosts"],
     () => getPosts(),
-    { cacheTime: 5000 },
+    {
+      staleTime: 60000,
+      cacheTime: 120000
+    },
   );
 
   if (isLoading) return "커뮤니티 게시글 로딩중";

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -114,19 +114,19 @@ export interface Database {
       like_product: {
         Row: {
           createdAt: string | null
-          number_likes: number | null
+          like_id: string
           product_uid: string
           user_id: string | null
         }
         Insert: {
           createdAt?: string | null
-          number_likes?: number | null
+          like_id?: string
           product_uid: string
           user_id?: string | null
         }
         Update: {
           createdAt?: string | null
-          number_likes?: number | null
+          like_id?: string
           product_uid?: string
           user_id?: string | null
         }


### PR DESCRIPTION
- 게시글 데이터 조회에 대한 stale time과 cache time을 설정해주었습니다
  - `staleTime` : staleTime이 지나기 전까지는 데이터가 fresh한 상태이고, 그 이후에는 stale한(오래된 데이터라는 의미) 상태가 됩니다.
  - `cacheTime` : 데이터가 inactive된 이후에 얼마동안 캐시 데이터로 저장할지 시간을 정해줍니다.
  - 설정이유 : 전체보기에서 제품 카테고리로 넘어가면, 전체보기 데이터가 inactive 되면서 캐시 타임의 디폴트값인 5초동안만 캐시에 유지됩니다. 이로 인해서 잠깐 제품 카테고리를 보고나서 다시 전체보기를 누르면 서버에서 데이터를 다시 불러오기 때문에 UX 측면에서 좋지 않다고 판단하였습니다. 게시글이 실시간으로 많이 올라오지 않는 특성상 cache time을 디폴트 5초에서 2분으로 설정해주었고, stale time을 1분으로 설정하여 1분이 지날 때마다 다시 데이터를 받아와서 fresh한 데이터를 보여줄 수 있도록 하였습니다.