### PR TITLE
fix/myprofile-dailyMission-modal

### DIFF
--- a/src/app/profile/[id]/mymission/missiondone/page.tsx
+++ b/src/app/profile/[id]/mymission/missiondone/page.tsx
@@ -55,7 +55,7 @@ const MissionDone = ({ params }: { params: { id: string } }) => {
           {missionDone?.map((mission) => {
             return (
               <div
-                className="py-6 px-4 flex flex-col justify-between items-center w-[180px] h-[300px] rounded-2xl break-words relative hover:scale-110 hover:duration-500 opacity-70 bg-[#F3FFEA]"
+                className="relative py-6 px-4 flex flex-col justify-between items-center w-[180px] h-[300px] rounded-2xl break-words hover:scale-110 hover:duration-500 opacity-70 bg-[#F3FFEA]"
                 key={mission.id}
               >
                 {/* 내용 및 버튼 */}

--- a/src/app/profile/[id]/mymission/missiondone/showMissionDone.tsx
+++ b/src/app/profile/[id]/mymission/missiondone/showMissionDone.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+const showMissionDone = ( {mission}: any) => {
+  return (
+    <div
+      // className="py-6 px-4 flex flex-col justify-between items-center w-[180px] h-[300px] rounded-2xl break-words hover:scale-110 hover:duration-500 bg-[#F3FFEA]"
+      className="py-6 px-4 flex flex-col justify-between items-center w-[180px] h-[300px] rounded-2xl break-words bg-[#F3FFEA]"
+      key={mission.id}
+    >
+      {/* 내용 및 버튼 */}
+      <div className="flex flex-col gap-3 items-start self-stretch opacity-100">
+        <h1 className="text-[24px] leading-[31px] font-semibold text-[#4DAB00]">
+          {mission.title}
+        </h1>
+
+        <div className="flex flex-col items-start gap-2 self-stretch">
+          <div className="min-h-[127px] min-w-[121px] flex py-4 px-2 flex-col justify-between items-start gap-2 self-stretch bg-[#E8FFD4] rounded-2xl">
+            <p className="text-[14px] font-medium text-[#5FD100]">
+              {mission.content}
+            </p>
+            <p className="text-gray-500">
+              {mission &&
+                mission.createdAt &&
+                mission.createdAt.replaceAll("-", ".")}
+              까지
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 이미지 및 "미션 완료" 부분 */}
+        <div className="w-full h-full flex flex-col justify-center items-center object-cover gap-4">
+        <div className="bg-white rounded-full p-4 flex justify-center ">
+          <svg
+            width="41"
+            height="40"
+            viewBox="0 0 41 40"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g id="Icon">
+              <path
+                id="Vector (Stroke)"
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M35.0118 10.4882C35.6627 11.139 35.6627 12.1943 35.0118 12.8452L18.3452 29.5118C17.6943 30.1627 16.639 30.1627 15.9881 29.5118L7.65481 21.1785C7.00394 20.5276 7.00394 19.4724 7.65481 18.8215C8.30569 18.1706 9.36096 18.1706 10.0118 18.8215L17.1667 25.9763L32.6548 10.4882C33.3057 9.83728 34.361 9.83728 35.0118 10.4882Z"
+                fill="#5FD100"
+              />
+            </g>
+          </svg>
+        </div>
+        <p className="text-[#4DAB00] text-2xl leading-6 font-semibold">
+          미션 완료!
+        </p>
+      </div>
+
+      {/* 버튼 */}
+      <button
+        disabled
+        className="flex py-2 px-[10px] justify-center items-center gap-[10px] bg-[#5FD100] rounded-2xl text-[#FCFCFD]"
+        onClick={() =>
+          mission.bigCategory === "글쓰기"
+            ? window.open("/community")
+            : window.open("/product")
+        }
+      >
+        미션하러 가기
+      </button>
+    </div>
+  );
+};
+
+export default showMissionDone;

--- a/src/app/profile/[id]/myprofile/page.tsx
+++ b/src/app/profile/[id]/myprofile/page.tsx
@@ -8,8 +8,6 @@ import EditProfile from "@/components/profile/EditProfile";
 
 type Profile = Database["public"]["Tables"]["user"]["Row"];
 const MyProfile = async ({ params: { id } }: { params: { id: string } }) => {
-  // let { data: user, error } = await supabase.from("user").select("*").eq("uid", "bd2125b8-d852-485c-baf3-9c7a8949beee")
-  // let { data: user, error } = await supabase.from("user").select("*").eq("uid", "bd2125b8-d852-485c-baf3-9c7a8949beed")
   let { data: user, error } = await supabase
     .from("user")
     .select("*")

--- a/src/app/profile/components/RandomMission.tsx
+++ b/src/app/profile/components/RandomMission.tsx
@@ -43,20 +43,12 @@ const initialProfile: any = {
 const RandomMission = ({ user, showModal, setShowModal, profile }: any) => {
   const currentDate = convertDate(new Date());
   const currentDateModify = currentDate.replaceAll("-", ".") as string;
-
-  // console.log("미션의 user",user)
   const searchId = user?.id || ("" as string);
 
   const [dailyMission, setDailyMission] = useState<DailyMission[]>([]);
   const [modalController, setModalController] = useState(showModal);
-  // console.log("showModal111,",showModal)
+
   useEffect(() => {
-    // console.log("showModal222,",showModal)
-    // console.log("modalController,",modalController)
-    // if(modalController === false) {
-    //   console.log("모달컨트롤러 false")
-    //   return
-    // }
     setModalController(showModal);
     insertMissionListData();
   }, [showModal]);

--- a/src/app/profile/components/SideBar.tsx
+++ b/src/app/profile/components/SideBar.tsx
@@ -22,24 +22,6 @@ export interface DailyMission {
   smallCategory: string;
 }
 
-const initialProfile: any = {
-  activePoint: null,
-  badges: null,
-  commentPosts: "",
-  email: "",
-  isActiveDone: false,
-  likedPosts: "",
-  likePosts: "",
-  likeProducts: null,
-  likeRestaurants: "",
-  nickname: "",
-  password: "",
-  profileImage: "",
-  provider: "",
-  uid: "",
-  writePosts: "",
-};
-
 const SideBar = () => {
   const searchId = useParams().id as string;
   // const decodedParams = decodeURIComponent(params);
@@ -53,7 +35,7 @@ const SideBar = () => {
     return user![0];
   };
 
-  const [profile, setProfile] = useState<any>(initialProfile);
+  const [profile, setProfile] = useState<Profile>();
 
   const [showModal, setShowModal] = useState(false);
   const [user, setUser] = useState<any>();
@@ -100,7 +82,6 @@ const SideBar = () => {
     };
     fetchProfile();
   }, [searchId]);
-
   return (
     <div className="flex flex-col items-start gap-16 text-gray-900">
       <h1 className="text-[24px] non-italic font-semibold">마이페이지</h1>

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -17,7 +17,6 @@ export const metadata: Metadata = {
       'apple-tough-icon.png'
     ]
   },
-  // manifest: 'stie.webmanifest'
 };
 
 export default async function profileLayout({
@@ -25,17 +24,15 @@ export default async function profileLayout({
 }: {
   children: React.ReactNode;
 }) {
-  // const profiledata = await getProfile(id)
   return (
     <>
       <div className="flex h-full">
-      <div className="mt-20 w-[1200px] h-full flex items-start gap-x-8 bg-lightgreen bg-white">
-        {/* <div className="sticky top-20 w-[379px] h-full flex flex-col"> */}
-        <div className="sticky top-20 w-[339px] min-h-[690px] h-full flex flex-col shadow-xl shadow-black/20 rounded-2xl p-6 border-t-2">
+      <div className="relative mt-20 w-[1200px] h-full flex items-start gap-x-8 bg-lightgreen bg-white">
+        <div className="sticky top-20 w-[339px] min-h-[690px] h-full flex flex-col shadow-xl shadow-black/20 rounded-2xl p-6 border-t-2 z-10">
           <SideBar />
         </div>
         <section className="w-[829px] flex flex-col shrink-0 self-stretch bg-white shadow-xl shadow-black/20 rounded-2xl p-6 border-t-2 cursor-default">
-          {children}
+          {children}      
         </section>
       </div>
     </div>

--- a/src/components/profile/MissionCalendar.tsx
+++ b/src/components/profile/MissionCalendar.tsx
@@ -100,7 +100,8 @@ const MissionCalendar = () => {
       />
       {user && profile.uid === user.id && (
   <>
-    <p
+  {/* sidebar와 보이는 창 z index 문제 해결될 때까지 봉인 */}
+    {/* <p
       style={{
         background: "rgb(245, 245, 245)",
         textAlign: "center",
@@ -113,7 +114,7 @@ const MissionCalendar = () => {
     >
       일일미션 하러가기
     </p>
-    <RandomMission showModal={showModal} user={user} setShowModal={setShowModal} profile={profile} />
+    <RandomMission showModal={showModal} user={user} setShowModal={setShowModal} profile={profile} /> */}
   </>
 )}
       


### PR DESCRIPTION
이슈 : 나의 미션 -> 완료한 미션 탭에서 일일미션을 뽑았을 때 완료한 미션 카드에 모달이 가려지는 문제

원인
(1) 완료한 미션 카드에 "체크SVG"와 "미션완료!"텍스트를 덧입히기 위해 relative와 absolute 사용
(2) sidebar와 나의 미션페이지(children)은 서로 독립적인 레이어이기 때문에 z-index로 상위-하위가 안 나뉘어짐

임시조치
(1) sidebar와 children의 상위 div에 relative 속성 부여, sidebar에 z-index 10 부여
(2) 부작용 : sidebar가 children보다 화면에서 위에 있기 때문에 프로필 -> 미션캘릭더의 미션하러가기를 클릭할 때 pop-up되는 모달이 sidebar에 가려짐. 우선 해당 부분 주석처리 후 업로드